### PR TITLE
bigly: experimenting with integrating e280 science testing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.yaml]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build-vpx
-dist
-node_modules
-x
+/build-vpx
+/dist
+/node_modules
+/x

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build-vpx
 /dist
 /node_modules
+/temp
 /x

--- a/build.sh
+++ b/build.sh
@@ -3,11 +3,11 @@
 set -e
 
 export OPTIMIZE="-Os"
-export LDFLAGS="${OPTIMIZE}"
-export CFLAGS="${OPTIMIZE}"
-export CXXFLAGS="${OPTIMIZE}"
 export AR=emar
 export RANLIB=emranlib
+export CFLAGS="${OPTIMIZE} -msimd128 -flto -O3 -ftree-vectorize -fvectorize -fslp-vectorize"
+export CXXFLAGS="${OPTIMIZE} -msimd128 -O3 -ftree-vectorize -fvectorize -fslp-vectorize"
+export LDFLAGS="${OPTIMIZE} -msimd128"
 
 eval $@
 
@@ -42,6 +42,7 @@ echo "============================================="
 (
 	emcc \
 		${OPTIMIZE} \
+		-msimd128 \
 		-s STRICT=1 \
 		-s ALLOW_MEMORY_GROWTH=1 \
 		-s ASSERTIONS=0 \

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,13 @@
 			"license": "MIT",
 			"dependencies": {
 				"@benev/slate": "^0.3.0",
+				"@e280/comrade": "^0.0.0-12",
+				"@e280/stz": "^0.0.0-5",
 				"web-demuxer": "^2.3.3"
 			},
 			"devDependencies": {
 				"@benev/turtle": "^0.6.9",
+				"@e280/science": "^0.0.0",
 				"http-server": "^14.1.1",
 				"napa": "^3.0.0",
 				"npm-run-all": "^4.1.5",
@@ -87,6 +90,28 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
+		},
+		"node_modules/@e280/comrade": {
+			"version": "0.0.0-12",
+			"resolved": "https://registry.npmjs.org/@e280/comrade/-/comrade-0.0.0-12.tgz",
+			"integrity": "sha512-B8TEgM+IxpCg1vA1F9i6ngL8hGtixWcfdC7H9mq+XICRQmW3HsZBuI+n6ChODNKAsmFyjgDQ1+BjrgXwYeJsoQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@e280/stz": "^0.0.0-5",
+				"renraku": "^0.5.0-8"
+			}
+		},
+		"node_modules/@e280/science": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/@e280/science/-/science-0.0.0.tgz",
+			"integrity": "sha512-keoF3CbnMofGQ+LyVuyhshBNvyCqCFMnXQUkISFO10H0+erUeVCRH0NNJ42hCA2lDCBydAxAN5j2QY58fFz8wg==",
+			"license": "MIT"
+		},
+		"node_modules/@e280/stz": {
+			"version": "0.0.0-5",
+			"resolved": "https://registry.npmjs.org/@e280/stz/-/stz-0.0.0-5.tgz",
+			"integrity": "sha512-Awhv4RFj6cSKnxb3Dc3bXVpcy+2rETZpPzLLnP3JHtWVbq8sq2xdhbwVb1BmWr+UtDRcMaklEXBSBFlw9AB4jA==",
+			"license": "MIT"
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.8",
@@ -4224,6 +4249,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/renraku": {
+			"version": "0.5.0-8",
+			"resolved": "https://registry.npmjs.org/renraku/-/renraku-0.5.0-8.tgz",
+			"integrity": "sha512-x3sIbgsI3v7wjfvYrMujBEaUQUCBEj1DPOL8b2Y2G2JImnChkRWa4h2Dx97uDjTjHODFBjqMHNmrcGJY7r4aEw==",
+			"license": "MIT",
+			"dependencies": {
+				"@e280/science": "^0.0.0",
+				"@e280/stz": "^0.0.0-5",
+				"ws": "^8.18.1"
+			}
+		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5582,6 +5618,27 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -5,18 +5,21 @@
 	"main": "x/index.js",
 	"type": "module",
 	"scripts": {
-		"build": "rm -rf x && run-s build-code build-ssg links copy-emscripten-build",
+		"build": "rm -rf x && run-s build-code build-ssg links copy-emscripten-build copy-demuxer-stuff",
 		"build-code": "turtle build --out=x",
 		"build-ssg": "turtle ssg --in=s,x,dist --out=x",
 		"build:emscripten": "docker run --rm -v $(pwd):/src emscripten/emsdk:3.1.6 ./build.sh",
 		"copy-emscripten-build": "cp -r dist x/",
-		"start": "run-p start-http start-turtle",
+		"copy-demuxer-stuff": "cp -r node_modules/web-demuxer/dist/wasm-files/ x/",
+		"start": "run-p start-http start-turtle test-watch",
 		"start-turtle": "turtle watch --in=s,x --out=x -v",
 		"start-http": "http-server x",
 		"links": "run-s links-s links-assets",
 		"links-s": "ln -s \"$(realpath s)\" x/s",
 		"links-assets": "ln -s \"$(realpath assets)\" x/assets",
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "node x/tests.test.js --verbose",
+		"test-watch": "node --watch x/tests.test.js --verbose",
+		"test-debug": "node inspect x/tests.test.js"
 	},
 	"keywords": [
 		"libvpx",
@@ -29,6 +32,7 @@
 	},
 	"devDependencies": {
 		"@benev/turtle": "^0.6.9",
+		"@e280/science": "^0.0.0",
 		"http-server": "^14.1.1",
 		"napa": "^3.0.0",
 		"npm-run-all": "^4.1.5",
@@ -36,6 +40,8 @@
 	},
 	"dependencies": {
 		"@benev/slate": "^0.3.0",
+		"@e280/comrade": "^0.0.0-12",
+		"@e280/stz": "^0.0.0-5",
 		"web-demuxer": "^2.3.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"build": "rm -rf x && run-s build-code build-ssg links copy-emscripten-build",
 		"build-code": "turtle build --out=x",
 		"build-ssg": "turtle ssg --in=s,x,dist --out=x",
-		"build:emscripten": "docker run --rm -v $(pwd):/src trzeci/emscripten:1.38.48 ./build.sh",
+		"build:emscripten": "docker run --rm -v $(pwd):/src emscripten/emsdk:2.0.26 ./build.sh",
 		"copy-emscripten-build": "cp -r dist x/",
 		"start": "run-p start-http start-turtle",
 		"start-turtle": "turtle watch --in=s,x --out=x -v",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"build": "rm -rf x && run-s build-code build-ssg links copy-emscripten-build",
 		"build-code": "turtle build --out=x",
 		"build-ssg": "turtle ssg --in=s,x,dist --out=x",
-		"build:emscripten": "docker run --rm -v $(pwd):/src emscripten/emsdk:2.0.26 ./build.sh",
+		"build:emscripten": "docker run --rm -v $(pwd):/src emscripten/emsdk:3.1.6 ./build.sh",
 		"copy-emscripten-build": "cp -r dist x/",
 		"start": "run-p start-http start-turtle",
 		"start-turtle": "turtle watch --in=s,x --out=x -v",
@@ -25,7 +25,7 @@
 	"author": "Przemysław Gałęzki",
 	"license": "MIT",
 	"napa": {
-		"libvpx": "webmproject/libvpx#v1.7.0"
+		"libvpx": "webmproject/libvpx#v1.15.1"
 	},
 	"devDependencies": {
 		"@benev/turtle": "^0.6.9",

--- a/s/decoder/parts/player.ts
+++ b/s/decoder/parts/player.ts
@@ -1,4 +1,7 @@
 import {VpxDecoder} from "../vpx-decoder.js"
+import {FpsCounter} from "../utils/fps-counter.js"
+
+const fps = new FpsCounter()
 
 export class Player extends VpxDecoder {
 	canvas = document.createElement("canvas")
@@ -15,6 +18,8 @@ export class Player extends VpxDecoder {
 	async play() {
 		if(this.demuxer.source && this.info && !this.#playing) {
 			this.#playing = true
+			fps.start()
+
 			const videoInfo = this.info.streams.find(stream => stream.codec_type_string === "video")
 			const framerate = this.parseFramerate(videoInfo?.avg_frame_rate!)
 			const start = this.currentFrame * (1 / framerate)
@@ -22,6 +27,9 @@ export class Player extends VpxDecoder {
 
 			while(true) {
 				const {done, value} = await reader.read()
+
+				fps.tick()
+
 				if(value) {
 					if(start <= value.timestamp) {
 						const frameNumber = Math.round(value.timestamp * framerate)

--- a/s/decoder/vpx-decoder.ts
+++ b/s/decoder/vpx-decoder.ts
@@ -1,6 +1,4 @@
-import type {WebDemuxer as Demuxer, WebMediaInfo} from "web-demuxer"
-//@ts-ignore
-import {WebDemuxer} from "web-demuxer/dist/web-demuxer.js"
+import {WebDemuxer, WebMediaInfo} from "web-demuxer"
 
 //@ts-ignore
 import Module from '../../dist/my-module.js'
@@ -11,7 +9,7 @@ import {getFrame} from "./parts/get-frame.js"
 export class VpxDecoder {
 	#module: any
 	protected info: WebMediaInfo | null = null
-	protected demuxer: Demuxer = new WebDemuxer({wasmLoaderPath: import.meta.resolve("web-demuxer/dist/wasm-files/ffmpeg.js")})
+	protected demuxer = new WebDemuxer({wasmLoaderPath: "wasm-files/ffmpeg.js"})
 
 	protected currentFrame = 0
 

--- a/s/tests.test.ts
+++ b/s/tests.test.ts
@@ -1,0 +1,11 @@
+
+import {Science, test, expect} from "@e280/science"
+import {VpxDecoder} from "./decoder/vpx-decoder.js"
+
+await Science.run({
+	"instantiate decoder": test(async() => {
+		const decoder = new VpxDecoder()
+		expect(!!decoder).is(true)
+	}),
+})
+


### PR DESCRIPTION
tweaked gitignore, added editorconfig, and i attempted to setup tests.test.ts suite

but the module that emscripten emits a module that fails when it tries to create a Worker, i think?

comrade now has `Comrade.loadWasm` and `Comrade.loadWorker`, which should work in browsers and node.

but the emscripten module naively tries to load stuff its own way.

the docker build uses an old verison of emscripten.

probably, we should redo the emscripten build so it's using the freshest version, and investigate whether it's possible to take control of how workers and wasm are loaded, so we could use comrade's universally compatible fns like loadWasm and loadWorker...